### PR TITLE
MAJOR FIX: Fix Private Methods not getting mocked properly

### DIFF
--- a/InternalMock.Tests.Unit/Services/Foundations/ExampleService.cs
+++ b/InternalMock.Tests.Unit/Services/Foundations/ExampleService.cs
@@ -28,7 +28,6 @@ namespace InternalMock.Tests.Unit.Services.Foundations
             }
             catch (NullReferenceException exception)
             {
-                // illustrative only
                 throw exception;
             }
         }

--- a/InternalMock.Tests.Unit/Services/Foundations/ExampleService.cs
+++ b/InternalMock.Tests.Unit/Services/Foundations/ExampleService.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace InternalMock.Tests.Unit.Services.Foundations
+{
+    public class ExampleService
+    {
+        delegate void VoidFunction();
+
+        public void DoStuff()
+        {
+            TryCatch(() =>
+            {
+                DoPrivateStuff();
+            });
+        }
+
+        void TryCatch(VoidFunction voidFunction)
+        {
+            try
+            {
+                voidFunction();
+            }
+            catch (NullReferenceException exception)
+            {
+                // illustrative only
+                throw exception;
+            }
+        }
+
+        void DoPrivateStuff() { }
+    }
+}

--- a/InternalMock.Tests.Unit/Services/Foundations/ExampleService.cs
+++ b/InternalMock.Tests.Unit/Services/Foundations/ExampleService.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using System;
 
 namespace InternalMock.Tests.Unit.Services.Foundations
 {

--- a/InternalMock.Tests.Unit/Services/Foundations/Patchings/PatchServiceTests.Logic.cs
+++ b/InternalMock.Tests.Unit/Services/Foundations/Patchings/PatchServiceTests.Logic.cs
@@ -4,8 +4,9 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
-using System.Reflection;
+using InternalMock.Extensions;
 using Moq;
+using System.Reflection;
 using Xunit;
 
 namespace InternalMock.Tests.Unit.Services.Foundations.Patchings
@@ -45,6 +46,23 @@ namespace InternalMock.Tests.Unit.Services.Foundations.Patchings
                         Times.Once);
 
             this.patchBrokerMock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void ShouldPatchPrivateMethods()
+        {
+            // given
+            var randomException = RandomException();
+            var exampleService = new ExampleService();
+
+            // when
+            exampleService.Mock("DoPrivateStuff")
+                .Throws(randomException);
+
+            void actualProblem() => exampleService.DoStuff();
+
+            // then
+            Assert.Throws(randomException.GetType(), actualProblem);
         }
 
         [Fact]

--- a/InternalMock.Tests.Unit/Services/Foundations/Patchings/PatchServiceTests.Logic.cs
+++ b/InternalMock.Tests.Unit/Services/Foundations/Patchings/PatchServiceTests.Logic.cs
@@ -4,8 +4,10 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
+using FluentAssertions;
 using InternalMock.Extensions;
 using Moq;
+using System;
 using System.Reflection;
 using Xunit;
 
@@ -50,6 +52,24 @@ namespace InternalMock.Tests.Unit.Services.Foundations.Patchings
 
         [Fact]
         public void ShouldPatchPrivateMethods()
+        {
+            // given
+            var expectedException = new InvalidOperationException();
+            var exampleService = new ExampleService();
+
+            // when
+            exampleService.Mock("DoPrivateStuff")
+                .Throws(expectedException);
+
+            void actualProblem() => exampleService.DoStuff();
+
+            // then
+            var actualException = Assert.Throws<InvalidOperationException>(actualProblem);
+            actualException.Should().BeEquivalentTo(expectedException);
+        }
+
+        [Fact]
+        public void ShouldPatchPrivateMethodsWithRandomException()
         {
             // given
             var randomException = RandomException();

--- a/InternalMock.Tests.Unit/Services/Foundations/Patchings/PatchServiceTests.cs
+++ b/InternalMock.Tests.Unit/Services/Foundations/Patchings/PatchServiceTests.cs
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------
 
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -66,5 +67,22 @@ namespace InternalMock.Tests.Unit.Services.Foundations.Patchings
                 returnType: randomType,
                 parameterTypes: randomTypes);
         }
+
+        static Exception RandomException()
+            => new Exception []
+                {
+                    new Exception(),
+                    new NullReferenceException(),
+                    new OutOfMemoryException(),
+                    new ValidationException(),
+                    new InvalidCastException(),
+                    new InvalidFilterCriteriaException(),
+                    new InvalidOperationException(),
+                    new InvalidTimeZoneException(),
+                    new InvalidProgramException()
+                }
+                .Skip(new IntRange(0, 7)
+                .GetValue())
+                .First();
     }
 }

--- a/InternalMock.Tests.Unit/Services/Foundations/Reflections/ReflectionServiceTests.Logic.cs
+++ b/InternalMock.Tests.Unit/Services/Foundations/Reflections/ReflectionServiceTests.Logic.cs
@@ -53,9 +53,12 @@ namespace InternalMock.Tests.Unit.Services.Foundations.Reflections
         public void ShouldRetrievePrivateMethodInfo()
         {
             // given
-            var reflectionService = new ReflectionService(new ReflectionBroker());
-            var privateMethodName = "DoPrivateStuff";
+            ReflectionService reflectionService = 
+                new ReflectionService(new ReflectionBroker());
+
+            string privateMethodName = "DoPrivateStuff";
             Type targetType = typeof(ExampleService);
+
             MethodInfo expectedMethodInfo = targetType.GetMethod(
                 privateMethodName, 
                 BindingFlags.Instance | BindingFlags.NonPublic);

--- a/InternalMock.Tests.Unit/Services/Foundations/Reflections/ReflectionServiceTests.Logic.cs
+++ b/InternalMock.Tests.Unit/Services/Foundations/Reflections/ReflectionServiceTests.Logic.cs
@@ -8,6 +8,8 @@ using System;
 using System.Reflection;
 using FluentAssertions;
 using Force.DeepCloner;
+using InternalMock.Brokers.Reflections;
+using InternalMock.Services.Foundations.Reflections;
 using Moq;
 using Xunit;
 
@@ -45,6 +47,27 @@ namespace InternalMock.Tests.Unit.Services.Foundations.Reflections
                     Times.Once);
 
             this.reflectionBrokerMock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void ShouldRetrievePrivateMethodInfo()
+        {
+            // given
+            var reflectionService = new ReflectionService(new ReflectionBroker());
+            var privateMethodName = "DoPrivateStuff";
+            Type targetType = typeof(ExampleService);
+            MethodInfo expectedMethodInfo = targetType.GetMethod(
+                privateMethodName, 
+                BindingFlags.Instance | BindingFlags.NonPublic);
+
+            // when
+            MethodInfo actualMethodInfo =
+                reflectionService.RetrieveMethodInformation(
+                    targetType,
+                    privateMethodName);
+
+            // then
+            actualMethodInfo.Should().BeSameAs(expectedMethodInfo);
         }
     }
 }

--- a/InternalMock/Brokers/Reflections/ReflectionBroker.cs
+++ b/InternalMock/Brokers/Reflections/ReflectionBroker.cs
@@ -15,7 +15,7 @@ namespace InternalMock.Brokers.Reflections
         {
             return type.GetMethod(
                 methodName,
-                bindingAttr: BindingFlags.NonPublic | BindingFlags.Static);
+                bindingAttr: BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Static);
         }
     }
 }


### PR DESCRIPTION
Note:

When all tests are run together the system runs in to a threading bug due to the static exception defined in InternalMockOrchestrationService

I tried to find ways to pass in "thread safe variations" but hit some weirdness.
I think we need to figure out how to pass the method itself down in to the Harmony lib then have that hold a reference to it to use or hold non static references higher up the application stack somewhere.

Bottom line ... it works but not multi threaded.
I'll think more on this one.